### PR TITLE
Fixed roughly after updates to isapprox, fixes #6

### DIFF
--- a/src/FactCheck.jl
+++ b/src/FactCheck.jl
@@ -358,12 +358,19 @@ exactly(x) = (y) -> is(x, y)
 #     @fact 4.99999 => roughly(5)
 #
 
-roughly(n::Number, rtol::Number, atol::Number) = (i) -> isapprox(i,n,rtol,atol)
-roughly(n::Number, tol::Number) = (i) -> isapprox(i, n, tol, tol)
-roughly(n::Number) = (i) -> isapprox(i,n)
+roughly(n::Number; kvtols...) = i::Number -> isapprox(i,n; kvtols...)
 
-roughly(X::AbstractArray) = Y::AbstractArray -> size(X) == size(Y) ? all(isapprox(X,Y)) : error("Arrays must be the same size (first was $(size(X)), second was $(size(Y))")
-roughly(X::AbstractArray, tol::Number) = roughly(X,tol,tol)
-roughly(X::AbstractArray, rtol::Number, atol::Number) = Y::AbstractArray -> size(X) == size(Y) ? all(isapprox(X,Y,rtol,atol)) : error("Arrays must be the same size (first was $(size(X)), second was $(size(Y))")
+roughly(X::AbstractArray; kvtols...) = Y::AbstractArray -> begin
+    if size(X) != size(Y) 
+        return false
+    end
+
+    for i in 1:length(X)
+        if !isapprox(X[i], Y[i]; kvtols...)
+            return false
+        end
+    end
+    return true
+end
 
 end # module FactCheck

--- a/test/test_factcheck.jl
+++ b/test/test_factcheck.jl
@@ -82,14 +82,16 @@ end
 
     @fact "`roughly` compares numbers... roughly" begin
         2.4999999999999 => roughly(2.5) #roughly(2.5)(2.4999) => true
-        9.5 => roughly(10, 1.0) #roughly(10, 1)(9.5) => true
-        10.5 => roughly(10, 1.0) #roughly(10, 1)(10.5) => true
+        9.5 => roughly(10; atol=1.0) #roughly(10, 1)(9.5) => true
+        10.5 => roughly(10; atol=1.0) #roughly(10, 1)(10.5) => true
     end
 
     @fact "`roughly` compares matrixes... roughly" begin
         X = [1.1 1.2; 2.1 2.2]
         Y = X + [0 0.000001; -0.00000349 0.00001]
+        Z = [1 1; 2 2]
         X => roughly(Y)
+        X => roughly(Z; atol=0.2)
     end
 
 end


### PR DESCRIPTION
Re-implemented the `roughly` helpers to cope with the fact that the API for `isapprox` was changed when it was merged into `Base`. This takes care of #6.
