### PR TITLE
fix README example s/begin/do in first context example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Related facts can also be grouped inside of a `context`:
 ```jl
 facts("Simple facts") do
 
-    context("numbers are themselves") begin
+    context("numbers are themselves") do
         @fact 1 => 1
         @fact 2 => 2
         @fact 3 => 3


### PR DESCRIPTION
Didn't catch this on the first pass of the README
