### PR TITLE
Adds option only_stats for low memory scenarios.

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ Compact vs default: .F...
 
 The main difference is that single characters only are emitted as the tests run, with all errors only being displayed at the end.
 
+#### Low memory situations
+
+If you run into problems using `FactCheck` in low memory situations like `Travis` consider to activate the option `only_stats`. This will not store results during the testing and provides only statistics in the end. This can be set with `FactCheck.onlystats(true)`.
+
+```
+
 ### Workflow
 
 You can run your tests simply by calling them from the command line, e.g. `julia --color test/runtests.jl`, but another option is to place your tests in a module, e.g.


### PR DESCRIPTION
Over at OpenCL.jl we repeatedly run into the problem that our tests failed on Travis due to out-of-memory errors. We mitigated this by starting a Julia instance for each test, but this is ugly and wastes time. So we determined that the core problem is that FactCheck retains references to the code that is run and that blocks garbage collection on the OpenCL side. On some OpenCL implementation all OpenCl objects have to be reference free before any can be collected... 

This PR adds a flag that can be set with FactCheck.onlystats(true), which prevents storing results in the allresults global array and instead directly stores the statistics.

For reference
JuliaGPU/OpenCL.jl#61
JuliaGPU/OpenCL.jl#43

cc @jakebolewski 
