### PR TITLE
add missing start of code block in README.ml

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ facts("Some pending") do
     @pending divide(2,3) => :something
 end
 ```
+produces
+```
 Some pending
 Out of 2 total facts:
   Verified: 1


### PR DESCRIPTION
This PR fixes a malformed code block causing the subsequent "### Assertion" to appear within a code block.