### PR TITLE
Fix failing test on 0.4-dev

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -110,8 +110,10 @@ facts("Testing 'context'") do
 
             redirect_stdout(original_STDOUT)
             # current LEVEL is 3
-            @fact system_output => "       - intended\n"
+            expected_str = "       - intended\n"
             # "  " ^ 3 * " - " * "intended\n"
+            @fact system_output => (VERSION >= v"0.4-dev" ?
+                                    expected_str.data : expected_str)
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,11 +108,11 @@ facts("Testing 'context'") do
             system_output = readavailable(out_read)
             close(out_read)
 
+            redirect_stdout(original_STDOUT)
             # current LEVEL is 3
-            @fact system_output => "       - intended\n" # "  " ^ 3 * " - " * "intended\n"
+            @fact system_output => "       - intended\n"
+            # "  " ^ 3 * " - " * "intended\n"
         end
-
-        redirect_stdout(original_STDOUT)
     end
 end
 


### PR DESCRIPTION
This make sure that a failing test (as it currently does on `0.4-dev`) does not generate a IO error.

Edit: and also fixed the failing test.
