### PR TITLE
Better Failure message

### DIFF
--- a/src/FactCheck.jl
+++ b/src/FactCheck.jl
@@ -146,7 +146,7 @@ print_compact(s::Pending) = print_with_color(:yellow, "P")
 
 const VALID_FACTCHECK_FUNCTIONS = Set([:not, :anything, :truthy, :falsey, :exactly, :roughly, :anyof, 
                                        :less_than, :less_than_or_equal, :greater_than, :greater_than_or_equal])
-const FACTCHECK_FUN_NAMES = Dict{Symbol,String}(:roughly => "≅",
+@compat const FACTCHECK_FUN_NAMES = Dict{Symbol,String}(:roughly => "≅",
                                                 :less_than => "<",
                                                 :less_than_or_equal => "≤",
                                                 :greater_than => ">",


### PR DESCRIPTION
Before this was the message:
```
  Failure   :: (line:-1) :: one doesn't equal two! :: got 1
    1 => 2
```

and now it looks like:
```
  Failure   :: (line:-1) :: one doesn't equal two! :: Expected 1, but got 2
    1 => 2
```

Here's another example... it was really tricky before to debug using the failure message without both values:
```
julia> using FactCheck

julia> x = rand(10); y = x + 10 - 10.1;

julia> @fact x => roughly(y)
Failure :: (line:-1) :: Expected [0.7667503484317708,0.6717338896415181,0.8021493665042585,0.9039190471453316,0.3397832778972987,0.37767761526026455,0.6320057426987593,0.9269198900115758,0.9224851192692733,0.7035056980788796], but got [0.666750348431771,0.5717338896415178,0.7021493665042584,0.8039190471453317,0.23978327789729903,0.2776776152602647,0.5320057426987592,0.8269198900115757,0.8224851192692739,0.6035056980788802]
x => roughly(y)
```

Comments welcome.