### PR TITLE
don't use pointwise isapprox for rough array comparisons

### DIFF
--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -35,17 +35,11 @@ roughly(x::Number; kvtols...) = (y::Number) -> isapprox(y, x; kvtols...)
 
 roughly(A::AbstractArray, atol) = (B::AbstractArray) -> begin
     size(A) != size(B) && return false
-    for i in 1:length(A)
-        !isapprox(A[i], B[i], atol=atol) && return false
-    end
-    return true
+    return isapprox(A, B, atol=atol)
 end
 roughly(A::AbstractArray; kvtols...) = (B::AbstractArray) -> begin
     size(A) != size(B) && return false
-    for i in 1:length(A)
-        !isapprox(A[i], B[i]; kvtols...) && return false
-    end
-    return true
+    return isapprox(A, B; kvtols...)
 end
 
 # anyof: match any of the arguments


### PR DESCRIPTION
As discussed in JuliaLang/julia#12393, the `roughly` comparison for arrays is not really right, because it does a pointwise `isapprox` comparison.   Without a user-specified absolute tolerance, this will make `[0,1]` not be roughly equal to `[1e-15,1]`, which is probably not intended.

This changes the test to use the new `isapprox` array functions from JuliaLang/julia#12472.

This PR should probably wait until JuliaLang/Compat.jl#130 lands and is tagged so that the corresponding Compat version can be required.